### PR TITLE
static files, linking style sheet with template

### DIFF
--- a/django_into_env/mysite/edibles/static/edibles/style.css
+++ b/django_into_env/mysite/edibles/static/edibles/style.css
@@ -1,0 +1,3 @@
+body{
+  background-color: rgb(132, 139, 89);
+}

--- a/django_into_env/mysite/edibles/templates/edibles/index.html
+++ b/django_into_env/mysite/edibles/templates/edibles/index.html
@@ -1,7 +1,20 @@
-{% for item in item_list %}
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Document</title>
+	<link rel="stylesheet" href="{% static 'edibles/style.css' %}">
+</head>
+<body>
+	{% for item in item_list %}
 	<ul>
 		<li>
 			<a href="{% url 'edibles:detail' item.id %}">{{item.id}}  --  {{item.item_name}}</a>
 		</li>
 	</ul>
 {% endfor %}
+</body>
+</html>


### PR DESCRIPTION
How to manage static files (e.g. images, JavaScript, CSS)[¶](https://docs.djangoproject.com/en/4.1/howto/static-files/#how-to-manage-static-files-e-g-images-javascript-css)
Websites generally need to serve additional files such as images, JavaScript, or CSS. In Django, we refer to these files as “static files”. Django provides [django.contrib.staticfiles](https://docs.djangoproject.com/en/4.1/ref/contrib/staticfiles/#module-django.contrib.staticfiles) to help you manage them.

This page describes how you can serve these static files.

Configuring static files[¶](https://docs.djangoproject.com/en/4.1/howto/static-files/#configuring-static-files)
Make sure that django.contrib.staticfiles is included in your [INSTALLED_APPS](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-INSTALLED_APPS).

In your settings file, define [STATIC_URL](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-STATIC_URL), for example: